### PR TITLE
Fix: allow user not to choose if field is not required

### DIFF
--- a/app/lib/server/functions/validateCustomFields.js
+++ b/app/lib/server/functions/validateCustomFields.js
@@ -29,6 +29,10 @@ export const validateCustomFields = function(fields) {
 			throw new Meteor.Error('error-user-registration-custom-field', `Field ${ fieldName } is required`, { method: 'registerUser' });
 		}
 
+		if (fieldValue === '') {
+			return;
+		}
+
 		if (field.type === 'select' && field.options.indexOf(fields[fieldName]) === -1) {
 			throw new Meteor.Error('error-user-registration-custom-field', `Value for field ${ fieldName } is invalid`, { method: 'registerUser' });
 		}


### PR DESCRIPTION
A minor change to avoid throwing an error if the user sends a Select object with an empty property which isn't required.