### PR TITLE
Harden initAPN and sendAPN to guard against bad certs, add logging

### DIFF
--- a/app/push/server/apn.ts
+++ b/app/push/server/apn.ts
@@ -1,121 +1,151 @@
-import apn from 'apn';
-import { EJSON } from 'meteor/ejson';
+import apn from "apn";
+import { EJSON } from "meteor/ejson";
 
-import { logger } from './logger';
+import { logger } from "./logger";
 
 let apnConnection;
 
 export const sendAPN = ({ userToken, notification, _removeToken }) => {
-	if (typeof notification.apn === 'object') {
-		notification = Object.assign({}, notification, notification.apn);
-	}
+  if (typeof notification.apn === "object") {
+    notification = Object.assign({}, notification, notification.apn);
+  }
 
-	const priority = notification.priority || notification.priority === 0 ? notification.priority : 10;
+  const priority =
+    notification.priority || notification.priority === 0
+      ? notification.priority
+      : 10;
 
-	const note = new apn.Notification();
+  const note = new apn.Notification();
 
-	note.expiry = Math.floor(Date.now() / 1000) + 3600; // Expires 1 hour from now.
-	note.badge = notification.badge;
-	note.sound = notification.sound;
+  note.expiry = Math.floor(Date.now() / 1000) + 3600; // Expires 1 hour from now.
+  note.badge = notification.badge;
+  note.sound = notification.sound;
 
-	if (notification.contentAvailable != null) {
-		note.setContentAvailable(notification.contentAvailable);
-	}
+  if (notification.contentAvailable != null) {
+    note.setContentAvailable(notification.contentAvailable);
+  }
 
-	// adds category support for iOS8 custom actions as described here:
-	// https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/
-	// RemoteNotificationsPG/Chapters/IPhoneOSClientImp.html#//apple_ref/doc/uid/TP40008194-CH103-SW36
-	note.category = notification.category;
+  // adds category support for iOS8 custom actions as described here:
+  // https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/
+  // RemoteNotificationsPG/Chapters/IPhoneOSClientImp.html#//apple_ref/doc/uid/TP40008194-CH103-SW36
+  note.category = notification.category;
 
-	note.body = notification.text;
-	note.title = notification.title;
+  note.body = notification.text;
+  note.title = notification.title;
 
-	if (notification.notId != null) {
-		note.threadId = String(notification.notId);
-	}
+  if (notification.notId != null) {
+    note.threadId = String(notification.notId);
+  }
 
-	// Allow the user to set payload data
-	note.payload = notification.payload ? { ejson: EJSON.stringify(notification.payload) } : {};
+  // Allow the user to set payload data
+  note.payload = notification.payload
+    ? { ejson: EJSON.stringify(notification.payload) }
+    : {};
 
-	note.payload.messageFrom = notification.from;
-	note.priority = priority;
+  note.payload.messageFrom = notification.from;
+  note.priority = priority;
 
-	// Store the token on the note so we can reference it if there was an error
-	note.token = userToken;
-	note.topic = notification.topic;
-	note.mutableContent = 1;
+  // Store the token on the note so we can reference it if there was an error
+  note.token = userToken;
+  note.topic = notification.topic;
+  note.mutableContent = 1;
 
-	apnConnection.send(note, userToken).then((response) => {
-		response.failed.forEach((failure) => {
-			logger.debug(`Got error code ${ failure.status } for token ${ userToken }`);
+  if (!apnConnection) {
+    logger.error("APN connection is undefined. Skipping APN send.");
+    return;
+  }
 
-			if (['400', '410'].includes(failure.status)) {
-				logger.debug(`Removing token ${ userToken }`);
-				_removeToken({
-					apn: userToken,
-				});
-			}
-		});
-	});
+  try {
+    if (!apnConnection) throw new Error("APN connection is undefined");
+
+    apnConnection.send(note, userToken).then((response) => {
+      response.failed.forEach((failure) => {
+        logger.debug(`Got error code ${failure.status} for token ${userToken}`);
+
+        if (["400", "410"].includes(failure.status)) {
+          logger.debug(`Removing token ${userToken}`);
+          _removeToken({
+            apn: userToken,
+          });
+        }
+      });
+    });
+  } catch (e) {
+    logger.error("Error sending APN notification");
+    logger.error(e);
+  }
 };
 
 export const initAPN = ({ options, absoluteUrl }) => {
-	logger.debug('APN configured');
+  logger.debug("APN configured");
+  logger.info("APN init: cert length:", options.apn?.cert?.length);
+  logger.info("APN init: key length:", options.apn?.key?.length);
 
-	// Allow production to be a general option for push notifications
-	if (options.production === Boolean(options.production)) {
-		options.apn.production = options.production;
-	}
+  // Allow production to be a general option for push notifications
+  if (options.production === Boolean(options.production)) {
+    options.apn.production = options.production;
+  }
 
-	// Give the user warnings about development settings
-	if (options.apn.development) {
-		// This flag is normally set by the configuration file
-		logger.warn('WARNING: Push APN is using development key and certificate');
-	} else if (options.apn.gateway) {
-		// We check the apn gateway i the options, we could risk shipping
-		// server into production while using the production configuration.
-		// On the other hand we could be in development but using the production
-		// configuration. And finally we could have configured an unknown apn
-		// gateway (this could change in the future - but a warning about typos
-		// can save hours of debugging)
-		//
-		// Warn about gateway configurations - it's more a guide
+  // Give the user warnings about development settings
+  if (options.apn.development) {
+    // This flag is normally set by the configuration file
+    logger.warn("WARNING: Push APN is using development key and certificate");
+  } else if (options.apn.gateway) {
+    // We check the apn gateway i the options, we could risk shipping
+    // server into production while using the production configuration.
+    // On the other hand we could be in development but using the production
+    // configuration. And finally we could have configured an unknown apn
+    // gateway (this could change in the future - but a warning about typos
+    // can save hours of debugging)
+    //
+    // Warn about gateway configurations - it's more a guide
 
-		if (options.apn.gateway === 'gateway.sandbox.push.apple.com') {
-			// Using the development sandbox
-			logger.warn('WARNING: Push APN is in development mode');
-		} else if (options.apn.gateway === 'gateway.push.apple.com') {
-			// In production - but warn if we are running on localhost
-			if (/http:\/\/localhost/.test(absoluteUrl)) {
-				logger.warn('WARNING: Push APN is configured to production mode - but server is running from localhost');
-			}
-		} else {
-			// Warn about gateways we dont know about
-			logger.warn(`WARNING: Push APN unknown gateway "${ options.apn.gateway }"`);
-		}
-	} else if (options.apn.production) {
-		if (/http:\/\/localhost/.test(absoluteUrl)) {
-			logger.warn('WARNING: Push APN is configured to production mode - but server is running from localhost');
-		}
-	} else {
-		logger.warn('WARNING: Push APN is in development mode');
-	}
+    if (options.apn.gateway === "gateway.sandbox.push.apple.com") {
+      // Using the development sandbox
+      logger.warn("WARNING: Push APN is in development mode");
+    } else if (options.apn.gateway === "gateway.push.apple.com") {
+      // In production - but warn if we are running on localhost
+      if (/http:\/\/localhost/.test(absoluteUrl)) {
+        logger.warn(
+          "WARNING: Push APN is configured to production mode - but server is running from localhost"
+        );
+      }
+    } else {
+      // Warn about gateways we dont know about
+      logger.warn(`WARNING: Push APN unknown gateway "${options.apn.gateway}"`);
+    }
+  } else if (options.apn.production) {
+    if (/http:\/\/localhost/.test(absoluteUrl)) {
+      logger.warn(
+        "WARNING: Push APN is configured to production mode - but server is running from localhost"
+      );
+    }
+  } else {
+    logger.warn("WARNING: Push APN is in development mode");
+  }
 
-	// Check certificate data
-	if (!options.apn.cert || !options.apn.cert.length) {
-		logger.error('ERROR: Push server could not find cert');
-	}
+  // Check certificate data
+  if (!options.apn.cert || !options.apn.cert.length) {
+    logger.error("ERROR: Push server could not find cert");
+    throw new Error("Missing APN certificate");
+  }
 
-	// Check key data
-	if (!options.apn.key || !options.apn.key.length) {
-		logger.error('ERROR: Push server could not find key');
-	}
+  // Check key data
+  if (!options.apn.key || !options.apn.key.length) {
+    logger.error("ERROR: Push server could not find key");
+    throw new Error("Missing APN key");
+  }
 
-	// Rig apn connection
-	try {
-		apnConnection = new apn.Provider(options.apn);
-	} catch (e) {
-		logger.error('Error trying to initialize APN');
-		logger.error(e);
-	}
+  // Rig apn connection
+  try {
+    apnConnection = new apn.Provider(options.apn);
+  } catch (e) {
+    logger.error("Error trying to initialize APN");
+    logger.error(e);
+  }
+  if (!apnConnection) {
+    throw new Error(
+      "APN connection initialization failed: apnConnection is undefined"
+    );
+  }
 };

--- a/app/push/server/push.ts
+++ b/app/push/server/push.ts
@@ -52,6 +52,15 @@ export class PushClass {
     logger.debug("Configure", this.options);
 
     if (this.options.apn) {
+      console.log(
+        "[Push] Using APN cert length:",
+        this.options.apn?.cert?.length
+      );
+      console.log(
+        "[Push] Using APN key length:",
+        this.options.apn?.key?.length
+      );
+
       initAPN({ options: this.options, absoluteUrl: Meteor.absoluteUrl() });
     }
   }

--- a/server/lib/pushConfig.js
+++ b/server/lib/pushConfig.js
@@ -105,6 +105,7 @@ function configurePush() {
 		}
 
 		if (!apn.key || apn.key.trim() === '' || !apn.cert || apn.cert.trim() === '') {
+            console.warn('[Push] APN config is incomplete. Disabling APN.');
 			apn = undefined;
 		}
 


### PR DESCRIPTION
The following error resulted from expired Apple certs, which must be renewed every year.

```
[2025-05-14T15:19:24.382Z] ERROR (System/1110737 on ip-172-31-18-215): Exception while invoking method getThreadMessages 'Error, too many requests. Please slow down. You must wait 60 seconds before trying again. [too-many-requests]'
[2025-05-14T15:19:24.384Z] ERROR (System/1110737 on ip-172-31-18-215): Exception while invoking method getThreadMessages 'Error, too many requests. Please slow down. You must wait 60 seconds before trying again. [too-many-requests]'
[2025-05-14T15:19:24.387Z] ERROR (System/1110737 on ip-172-31-18-215): Exception while invoking method getThreadMessages 'Error, too many requests. Please slow down. You must wait 60 seconds before trying again. [too-many-requests]'
[2025-05-14T15:19:24.391Z] ERROR (System/1110737 on ip-172-31-18-215): Exception while invoking method getThreadMessages 'Error, too many requests. Please slow down. You must wait 60 seconds before trying again. [too-many-requests]'
[2025-05-14T15:19:24.481Z] ERROR (System/1110737 on ip-172-31-18-215): Exception while invoking method getThreadMessages 'Error, too many requests. Please slow down. You must wait 60 seconds before trying again. [too-many-requests]'
[2025-05-14T15:19:24.484Z] ERROR (System/1110737 on ip-172-31-18-215): Exception while invoking method getThreadMessages 'Error, too many requests. Please slow down. You must wait 60 seconds before trying again. [too-many-requests]'
[2025-05-14T15:19:24.486Z] ERROR (System/1110737 on ip-172-31-18-215): Exception while invoking method getThreadMessages 'Error, too many requests. Please slow down. You must wait 60 seconds before trying again. [too-many-requests]'
[2025-05-14T15:19:24.499Z] ERROR (System/1110737 on ip-172-31-18-215): Exception while invoking method getThreadMessages 'Error, too many requests. Please slow down. You must wait 60 seconds before trying again. [too-many-requests]'
[2025-05-14T15:20:00.026Z] INFO (SyncedCron/1110737 on ip-172-31-18-215): Starting "Generate download files for user data".
[2025-05-14T15:20:00.027Z] INFO (SyncedCron/1110737 on ip-172-31-18-215): Finished "Generate download files for user data".
[2025-05-14T15:20:00.958Z] INFO (SyncedCron/1110737 on ip-172-31-18-215): Starting "Federation".
[2025-05-14T15:20:00.959Z] INFO (SyncedCron/1110737 on ip-172-31-18-215): Finished "Federation".
[2025-05-14T15:21:00.965Z] INFO (SyncedCron/1110737 on ip-172-31-18-215): Starting "Federation".
[2025-05-14T15:21:00.966Z] INFO (SyncedCron/1110737 on ip-172-31-18-215): Finished "Federation".
=== UnHandledPromiseRejection ===
TypeError: Cannot read property 'send' of undefined
    at sendAPN (app/push/server/apn.ts:48:16)
    at app/push/server/push.ts:141:9
    at /home/ubuntu/.meteor/packages/promise/.0.11.2.10h6v47.9sqi++os+web.browser+web.browser.legacy+web.cordova/npm/node_modules/meteor-promise/fiber_pool.js:43:40
---------------------------------
Errors like this can cause oplog processing errors.
Setting EXIT_UNHANDLEDPROMISEREJECTION will cause the process to exit allowing your service to automatically restart the process
Future node.js versions will automatically exit the process
=================================
Exited with code: 1
Your application is crashing. Waiting for file change.
=> Meteor 3.2.2 is available. Update this project with 'meteor update'.
```